### PR TITLE
feat(cmd): add ollama local inference support by limiting diff size f…

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -44,14 +44,19 @@ func runCommit(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	diff, err := git.GetStagedDiff()
-	if err != nil {
-		return fmt.Errorf("reading diff: %w", err)
-	}
-
 	cfg, err := config.Load()
 	if err != nil {
 		return err
+	}
+
+	limit := git.MaxDiffBytesCloud
+	if cfg.ResolveProvider() == provider.ProviderOllama {
+		limit = git.MaxDiffBytesLocal
+	}
+
+	diff, err := git.GetStagedDiff(limit)
+	if err != nil {
+		return fmt.Errorf("reading diff: %w", err)
 	}
 
 	p, err := provider.NewFromConfig(cfg)

--- a/cmd/split.go
+++ b/cmd/split.go
@@ -37,18 +37,23 @@ func runSplit(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	hunks, err := git.ParseHunks()
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	limit := git.MaxDiffBytesCloud
+	if cfg.ResolveProvider() == provider.ProviderOllama {
+		limit = git.MaxDiffBytesLocal
+	}
+
+	hunks, err := git.ParseHunks(limit)
 	if err != nil {
 		return fmt.Errorf("parsing hunks: %w", err)
 	}
 	if len(hunks) == 0 {
 		fmt.Fprintln(os.Stderr, "no hunks found in staged diff")
 		return nil
-	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		return err
 	}
 
 	p, err := provider.NewFromConfig(cfg)

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+const (
+	MaxDiffBytesLocal = 14_000
+	MaxDiffBytesCloud = 100_000
+)
+
 // IsGitRepo checks whether the current working dir is inside a git work tree.
 func IsGitRepo() bool {
 	return exec.Command("git", "rev-parse", "--is-inside-work-tree").Run() == nil
@@ -22,9 +27,7 @@ func HasStagedChanges() (bool, error) {
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
-const maxDiffBytes = 3_000
-
-func GetStagedDiff() (string, error) {
+func GetStagedDiff(maxBytes int) (string, error) {
 	var buf bytes.Buffer
 	cmd := exec.Command("git", "diff", "--cached", "--unified=3")
 	cmd.Stdout = &buf
@@ -38,7 +41,7 @@ func GetStagedDiff() (string, error) {
 		return "", fmt.Errorf("no staged changes - `git add <files>` to stage changes")
 	}
 
-	return truncateDiff(diff, maxDiffBytes), nil
+	return truncateDiff(diff, maxBytes), nil
 }
 
 func truncateDiff(diff string, maxBytes int) string {

--- a/internal/git/hunk.go
+++ b/internal/git/hunk.go
@@ -16,7 +16,7 @@ type Hunk struct {
 	Body     string
 }
 
-func ParseHunks() ([]Hunk, error) {
+func ParseHunks(maxBytes int) ([]Hunk, error) {
 	cmd := exec.Command("git", "diff", "--cached", "--unified=3")
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
@@ -25,7 +25,7 @@ func ParseHunks() ([]Hunk, error) {
 		return nil, fmt.Errorf("git diff --cached: %w", err)
 	}
 
-	return parseHunksFromDiff(buf.String())
+	return parseHunksFromDiff(truncateDiff(buf.String(), maxBytes))
 }
 
 // parseHunksFromDiff parses raw diff text into hunks.


### PR DESCRIPTION
…or provider-specific workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Diff processing now applies provider-specific size limits. Cloud and local Ollama providers use separate, optimized limits to handle their respective performance and scaling requirements more effectively.
  * Configuration loading sequence updated in commit and split workflows. The configuration is now loaded earlier, enabling provider-aware diff size limit selection and improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->