### PR TITLE
fix: Allow configuring models for OpenAI and Gemini

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -71,6 +71,22 @@ Example:
 	RunE: runSetOllamaModel,
 }
 
+var setOpenAIModelCmd = &cobra.Command{
+	Use:   "set-openai-model <chat-model> <embed-model>",
+	Short: "Set the OpenAI chat and embed models",
+	Long:  `Set the OpenAI models used for commit messages and gix split.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSetOpenAIModel,
+}
+
+var setGeminiModelCmd = &cobra.Command{
+	Use:   "set-gemini-model <chat-model> <embed-model>",
+	Short: "Set the Gemini chat and embed models",
+	Long:  `Set the Gemini models used for commit messages and gix split.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSetGeminiModel,
+}
+
 var keyProvider string
 
 func init() {
@@ -81,6 +97,8 @@ func init() {
 	configCmd.AddCommand(setUpdateCheckCmd)
 	configCmd.AddCommand(setOllamaURLCmd)
 	configCmd.AddCommand(setOllamaModelCmd)
+	configCmd.AddCommand(setOpenAIModelCmd)
+	configCmd.AddCommand(setGeminiModelCmd)
 	rootCmd.AddCommand(configCmd)
 }
 
@@ -172,5 +190,27 @@ func runSetOllamaModel(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("saving config: %w", err)
 	}
 	fmt.Printf("Ollama models set — chat: %q, embed: %q\n", cfg.OllamaChatModel, cfg.OllamaEmbedModel)
+	return nil
+}
+
+func runSetOpenAIModel(_ *cobra.Command, args []string) error {
+	cfg, _ := config.Load()
+	cfg.OpenAIChatModel = strings.TrimSpace(args[0])
+	cfg.OpenAIEmbedModel = strings.TrimSpace(args[1])
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	fmt.Printf("OpenAI models set — chat: %q, embed: %q\n", cfg.OpenAIChatModel, cfg.OpenAIEmbedModel)
+	return nil
+}
+
+func runSetGeminiModel(_ *cobra.Command, args []string) error {
+	cfg, _ := config.Load()
+	cfg.GeminiChatModel = strings.TrimSpace(args[0])
+	cfg.GeminiEmbedModel = strings.TrimSpace(args[1])
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	fmt.Printf("Gemini models set — chat: %q, embed: %q\n", cfg.GeminiChatModel, cfg.GeminiEmbedModel)
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	GeminiKey string `json:"gemini_key,omitempty"`
 	Provider  string `json:"provider,omitempty"`
 
+	OpenAIChatModel  string `json:"openai_chat_model,omitempty"`
+	OpenAIEmbedModel string `json:"openai_embed_model,omitempty"`
+	GeminiChatModel  string `json:"gemini_chat_model,omitempty"`
+	GeminiEmbedModel string `json:"gemini_embed_model,omitempty"`
+
 	OllamaBaseURL    string `json:"ollama_base_url,omitempty"`
 	OllamaChatModel  string `json:"ollama_chat_model,omitempty"`
 	OllamaEmbedModel string `json:"ollama_embed_model,omitempty"`

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -5,18 +5,24 @@ import "time"
 const (
 	openaiChatURL    = "https://api.openai.com/v1/chat/completions"
 	openaiEmbedURL   = "https://api.openai.com/v1/embeddings"
-	openaiChatModel  = "gpt-4o"
-	openaiEmbedModel = "text-embedding-3-small"
+	defaultOpenAIChatModel  = "gpt-4o"
+	defaultOpenAIEmbedModel = "text-embedding-3-small"
 )
 
 type OpenAI struct{ *chatClient }
 
-func NewOpenAI(apiKey string) *OpenAI {
+func NewOpenAI(apiKey, chatModel, embedModel string) *OpenAI {
+	if chatModel == "" {
+		chatModel = defaultOpenAIChatModel
+	}
+	if embedModel == "" {
+		embedModel = defaultOpenAIEmbedModel
+	}
 	return &OpenAI{newChatClient(
 		openaiChatURL,
 		openaiEmbedURL,
-		openaiChatModel,
-		openaiEmbedModel,
+		chatModel,
+		embedModel,
 		apiKey,
 		20*time.Second,
 	)}


### PR DESCRIPTION
Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added commands to configure OpenAI chat and embedding models.
  - Added commands to configure Gemini chat and embedding models.
  - Model selections are saved and displayed after configuration.
  - OpenAI integrations now use configured models, with defaults applied when no model is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->